### PR TITLE
修复获取不到 mysql 表注释的问题

### DIFF
--- a/src/main/java/cn/org/rapid_framework/generator/provider/db/table/TableFactory.java
+++ b/src/main/java/cn/org/rapid_framework/generator/provider/db/table/TableFactory.java
@@ -134,6 +134,9 @@ public class TableFactory {
 			if(remarks == null && dbHelper.isOracleDataBase()) {
 				remarks = getOracleTableComments(realTableName);
 			}
+			if ((null == remarks || "".equals(remarks)) && dbHelper.isMysqlDataBase()) {
+				remarks = getMysqlTableComments(getCatalog(), realTableName);
+			}
 			
 			Table table = new Table();
 			table.setSqlName(realTableName);
@@ -378,6 +381,11 @@ public class TableFactory {
 		return primaryKeys;
 	}
 
+	private String getMysqlTableComments(String tableSchema, String table) {
+		String sql = "SELECT TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '" + tableSchema + "' AND TABLE_NAME = '" + table + "'";
+		return dbHelper.queryForString(sql);
+	}
+
 	private String getOracleTableComments(String table)  {
 		String sql = "SELECT comments FROM user_tab_comments WHERE table_name='"+table+"'";
 		return dbHelper.queryForString(sql);
@@ -448,8 +456,15 @@ public class TableFactory {
 		public boolean isOracleDataBase() {
 			boolean ret = false;
 			try {
-				ret = (getMetaData().getDatabaseProductName().toLowerCase()
-						.indexOf("oracle") != -1);
+				ret = (getMetaData().getDatabaseProductName().toLowerCase().contains("oracle"));
+			} catch (Exception ignore) {
+			}
+			return ret;
+		}
+		public boolean isMysqlDataBase() {
+			boolean ret = false;
+			try {
+				ret = (getMetaData().getDatabaseProductName().toLowerCase().contains("mysql"));
 			} catch (Exception ignore) {
 			}
 			return ret;


### PR DESCRIPTION
通过 ResultSet.getString("REMARKS") 方法获取到的 mysql 表的注释，适中为 "" ，现通过另外一种方法获取 mysql 表的注释